### PR TITLE
fixed direction of some strings in Persian locale

### DIFF
--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -82,6 +82,6 @@
     <!-- Automatic filter -->
     <!-- automatic_filter_options_array -->
     <string name="automatic_filter_options_array_0">دستی</string>
-    <string name="automatic_filter_options_array_1">(خودکار (خورشید</string>
-    <string name="automatic_filter_options_array_2">(خودکار (شخصی</string>
+    <string name="automatic_filter_options_array_1">‫خودکار (خورشید)‬</string>
+    <string name="automatic_filter_options_array_2">‫خودکار (شخصی)‬</string>
 </resources>


### PR DESCRIPTION
fix a mis-ordering in Persian locale caused by parenthesis.