### PR TITLE
Make shortcut activities invisble

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -79,7 +79,8 @@
 
         <activity
             android:name="com.jmstudios.redmoon.activity.ShortcutCreationActivity"
-            android:label="@string/shortcut_activity" >
+            android:label="@string/shortcut_activity"
+            android:theme="@style/TransparentTheme" >
           <intent-filter>
             <action android:name="android.intent.action.CREATE_SHORTCUT"/>
             <category android:name="android.intent.category.DEFAULT"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -86,6 +86,15 @@
           </intent-filter>
         </activity>
 
+        <activity
+            android:name="com.jmstudios.redmoon.activity.ShortcutToggleActivity"
+            android:label="@string/shortcut_activity"
+            android:theme="@style/TransparentTheme">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+            </intent-filter>
+        </activity>
+
         <service
             android:name="com.jmstudios.redmoon.service.ScreenFilterService"
             android:enabled="true" >

--- a/app/src/main/java/com/jmstudios/redmoon/activity/ShadesActivity.java
+++ b/app/src/main/java/com/jmstudios/redmoon/activity/ShadesActivity.java
@@ -65,6 +65,8 @@ public class ShadesActivity extends AppCompatActivity {
     private static final boolean DEBUG = true;
     private static final String FRAGMENT_TAG_SHADES = "jmstudios.fragment.tag.SHADES";
 
+    // Only for compatibility with older shortcuts; new shortcuts will launch ShortcutToggleActivity
+    @Deprecated
     public static final String EXTRA_FROM_SHORTCUT_BOOL =
         "com.jmstudios.redmoon.activity.ShadesActivity.EXTRA_FROM_SHORTCUT_BOOL";
     public static int OVERLAY_PERMISSION_REQ_CODE = 1234;
@@ -84,7 +86,7 @@ public class ShadesActivity extends AppCompatActivity {
         if (DEBUG) Log.i(TAG, "Got intent");
         boolean fromShortcut = intent.getBooleanExtra(EXTRA_FROM_SHORTCUT_BOOL, false);
         if (fromShortcut) {
-            toggleAndFinish();
+            ShortcutToggleActivity.toggleAndFinish(this);
         }
 
         // Wire MVP classes
@@ -182,7 +184,7 @@ public class ShadesActivity extends AppCompatActivity {
     protected void onNewIntent(Intent intent) {
         boolean fromShortcut = intent.getBooleanExtra(EXTRA_FROM_SHORTCUT_BOOL, false);
         if (fromShortcut) {
-            toggleAndFinish();
+            ShortcutToggleActivity.toggleAndFinish(this);
         }
     }
 
@@ -230,25 +232,5 @@ public class ShadesActivity extends AppCompatActivity {
 
     public SettingsModel getSettingsModel() {
         return mSettingsModel;
-    }
-
-    private void toggleAndFinish() {
-        FilterCommandSender commandSender = new FilterCommandSender(this);
-        FilterCommandFactory commandFactory = new FilterCommandFactory(this);
-        Intent onCommand = commandFactory.createCommand(ScreenFilterService.COMMAND_ON);
-        Intent pauseCommand = commandFactory.createCommand(ScreenFilterService.COMMAND_PAUSE);
-
-        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
-        SettingsModel settingsModel = new SettingsModel(getResources(), sharedPreferences);
-        boolean poweredOn = settingsModel.getShadesPowerState();
-        boolean paused = settingsModel.getShadesPauseState();
-
-        if (!poweredOn || paused) {
-            commandSender.send(onCommand);
-        } else {
-            commandSender.send(pauseCommand);
-        }
-
-        finish();
     }
 }

--- a/app/src/main/java/com/jmstudios/redmoon/activity/ShortcutCreationActivity.java
+++ b/app/src/main/java/com/jmstudios/redmoon/activity/ShortcutCreationActivity.java
@@ -38,8 +38,7 @@ public class ShortcutCreationActivity extends Activity {
         if (DEBUG) Log.i(TAG, "Create ShortcutCreationActivity");
         super.onCreate(savedInstanceState);
 
-        Intent shortcutIntent = new Intent(this, ShadesActivity.class);
-        shortcutIntent.putExtra(ShadesActivity.EXTRA_FROM_SHORTCUT_BOOL, true);
+        Intent shortcutIntent = new Intent(this, ShortcutToggleActivity.class);
         shortcutIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP |
                                 Intent.FLAG_ACTIVITY_SINGLE_TOP);
 

--- a/app/src/main/java/com/jmstudios/redmoon/activity/ShortcutToggleActivity.java
+++ b/app/src/main/java/com/jmstudios/redmoon/activity/ShortcutToggleActivity.java
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+/*
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  *
  *  This file is free software: you may copy, redistribute and/or modify it
@@ -33,34 +32,46 @@
  *     OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
  *     NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  *     CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
--->
-<resources>
-    <!-- App Themes -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
-      <item name="colorPrimary">@color/color_primary</item>
-      <item name="colorPrimaryDark">@color/color_primary_dark</item>
-    </style>
+ */
+package com.jmstudios.redmoon.activity;
 
-    <style name="AppThemeDark" parent="Theme.AppCompat">
-      <item name="colorPrimary">@color/color_primary</item>
-      <item name="colorPrimaryDark">@color/color_primary_dark</item>
-    </style>
+import android.app.Activity;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
 
-    <!-- Preference TextView Style -->
-    <style name="PreferenceTextStyle">
-      <item name="android:textAppearance">@android:style/TextAppearance.Holo.Medium</item>
-      <item name="android:singleLine">true</item>
-      <item name="android:ellipsize">marquee</item>
-    </style>
+import com.jmstudios.redmoon.helper.FilterCommandFactory;
+import com.jmstudios.redmoon.helper.FilterCommandSender;
+import com.jmstudios.redmoon.model.SettingsModel;
+import com.jmstudios.redmoon.service.ScreenFilterService;
 
-    <style name="PreferenceSecundaryTextStyle">
-      <item name="android:textAppearance">@android:style/TextAppearance.Holo.Small</item>
-      <item name="android:singleLine">true</item>
-      <item name="android:ellipsize">marquee</item>
-    </style>
+public class ShortcutToggleActivity extends Activity {
 
-    <style name="TransparentTheme" parent="android:Theme">
-        <item name="android:windowIsTranslucent">true</item>
-    </style>
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        toggleAndFinish(this);
+    }
 
-</resources>
+    public static void toggleAndFinish(Activity activity) {
+        FilterCommandSender commandSender = new FilterCommandSender(activity);
+        FilterCommandFactory commandFactory = new FilterCommandFactory(activity);
+        Intent onCommand = commandFactory.createCommand(ScreenFilterService.COMMAND_ON);
+        Intent pauseCommand = commandFactory.createCommand(ScreenFilterService.COMMAND_PAUSE);
+
+        SharedPreferences sharedPreferences =
+                PreferenceManager.getDefaultSharedPreferences(activity);
+        SettingsModel settingsModel = new SettingsModel(activity.getResources(), sharedPreferences);
+        boolean poweredOn = settingsModel.getShadesPowerState();
+        boolean paused = settingsModel.getShadesPauseState();
+
+        if (!poweredOn || paused) {
+            commandSender.send(onCommand);
+        } else {
+            commandSender.send(pauseCommand);
+        }
+
+        activity.finish();
+    }
+}


### PR DESCRIPTION
Use a transparent theme for activities that are finished directly after creating so users can never see them. See the specific commit messages for more information.