### PR TITLE
Remove unused meta-data

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -115,11 +115,6 @@
             android:theme="@style/AppTheme"
             android:parentActivityName="com.jmstudios.redmoon.activity.ShadesActivity" >
 
-          <!-- Parent activity meta-data to support 4.0 and lower -->
-          <meta-data
-              android:name="android.support.PARENT_ACTIVITY"
-              android:value="com.jmstudios.redmoon.activity.ShadesActivity" />
-
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
If I am reading this right, this meta-data tag is only used in
Android 4.0 ICS (API 15) and lower. In the build.gradle
file the minSdkVersion is set to API 17 (Android 4.2 JB).