### PR TITLE
change to SPDX license identifiers

### DIFF
--- a/LICENSE.spdx
+++ b/LICENSE.spdx
@@ -1,0 +1,6 @@
+SPDXVersion: SPDX-2.1
+DataLicense: CC0-1.0
+PackageName: Red Moon
+PackageOriginator: Marien Raat
+PackageHomePage: https://github.com/raatmarien/red-moon
+PackageLicenseDeclared: GPL-3.0+

--- a/app/src/fdroid/java/com/jmstudios/redmoon/helper/RateDialog.kt
+++ b/app/src/fdroid/java/com/jmstudios/redmoon/helper/RateDialog.kt
@@ -1,18 +1,6 @@
 /*
  * Copyright (c) 2017 Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.helper
 

--- a/app/src/main/java/com/jmstudios/redmoon/activity/Intro.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/activity/Intro.kt
@@ -1,18 +1,6 @@
 /*
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.activity
 

--- a/app/src/main/java/com/jmstudios/redmoon/activity/MainActivity.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/activity/MainActivity.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/java/com/jmstudios/redmoon/activity/ShortcutCreationActivity.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/activity/ShortcutCreationActivity.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.activity
 

--- a/app/src/main/java/com/jmstudios/redmoon/activity/ThemedActivities.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/activity/ThemedActivities.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
+ * Copyright (c) 2017  Stephen Michel <s@smichel.me>
+ * SPDX-License-Identifier: GPL-3.0+
+ */
 package com.jmstudios.redmoon.activity
 
 import android.os.Bundle

--- a/app/src/main/java/com/jmstudios/redmoon/application/RedMoonApplication.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/application/RedMoonApplication.kt
@@ -1,18 +1,6 @@
 /*
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 
 package com.jmstudios.redmoon.application

--- a/app/src/main/java/com/jmstudios/redmoon/event/Events.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/event/Events.kt
@@ -1,18 +1,6 @@
 /*
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 
 package com.jmstudios.redmoon.event

--- a/app/src/main/java/com/jmstudios/redmoon/fragment/AboutFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/fragment/AboutFragment.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.fragment
 

--- a/app/src/main/java/com/jmstudios/redmoon/fragment/EventFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/fragment/EventFragment.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.fragment
 

--- a/app/src/main/java/com/jmstudios/redmoon/fragment/FilterFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/fragment/FilterFragment.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/java/com/jmstudios/redmoon/fragment/SecureSuspendFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/fragment/SecureSuspendFragment.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.fragment
 

--- a/app/src/main/java/com/jmstudios/redmoon/fragment/TimeToggleFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/fragment/TimeToggleFragment.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.fragment
 

--- a/app/src/main/java/com/jmstudios/redmoon/helper/AbstractAnimatorListener.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/helper/AbstractAnimatorListener.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/java/com/jmstudios/redmoon/helper/EventBus.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/helper/EventBus.kt
@@ -1,18 +1,6 @@
 /*
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 
 package com.jmstudios.redmoon.helper

--- a/app/src/main/java/com/jmstudios/redmoon/helper/Logger.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/helper/Logger.kt
@@ -1,18 +1,6 @@
 /*
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notices:

--- a/app/src/main/java/com/jmstudios/redmoon/helper/Permission.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/helper/Permission.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2017  Stephen Michel <s@smichel.me>
+ * SPDX-License-Identifier: GPL-3.0+
+ */
 package com.jmstudios.redmoon.helper
 
 import android.Manifest

--- a/app/src/main/java/com/jmstudios/redmoon/helper/Profile.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/helper/Profile.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017 Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.helper
 

--- a/app/src/main/java/com/jmstudios/redmoon/helper/Upgrade.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/helper/Upgrade.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
+ * Copyright (c) 2017 Stephen Michel <s@smichel.me>
+ * SPDX-License-Identifier: GPL-3.0+
+ */
 package com.jmstudios.redmoon.helper
 
 import android.content.Context

--- a/app/src/main/java/com/jmstudios/redmoon/manager/BrightnessManager.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/manager/BrightnessManager.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/java/com/jmstudios/redmoon/manager/CurrentAppMonitor.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/manager/CurrentAppMonitor.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.manager
 

--- a/app/src/main/java/com/jmstudios/redmoon/manager/ScreenManager.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/manager/ScreenManager.kt
@@ -1,18 +1,6 @@
 /*
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/java/com/jmstudios/redmoon/manager/WindowViewManager.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/manager/WindowViewManager.kt
@@ -1,18 +1,6 @@
 /*
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/java/com/jmstudios/redmoon/model/Config.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/model/Config.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/java/com/jmstudios/redmoon/model/ProfilesModel.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/model/ProfilesModel.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
+ * Copyright (c) 2017  Stephen Michel <s@smichel.me>
+ * SPDX-License-Identifier: GPL-3.0+
+ */
+package com.jmstudios.redmoon.model
+
+import android.content.Context
+import android.content.SharedPreferences
+
+import com.jmstudios.redmoon.R
+
+import com.jmstudios.redmoon.helper.Logger
+import com.jmstudios.redmoon.helper.Profile
+import com.jmstudios.redmoon.util.*
+
+/**
+ * This singleton manages the SharedPreference that store all custom
+ * filter profiles added by the user.
+ *
+ * The profiles are stored in a separate SharedPreference, with one key-value
+ * pair per profile. The key is their position in the list of profiles
+ * (an integer as a string). The value is a JSON string.
+ */
+
+object ProfilesModel: Logger() {
+
+    private const val PREFERENCE_NAME = "com.jmstudios.redmoon.PROFILES_PREFERENCE"
+    private const val MODE = Context.MODE_PRIVATE
+
+    private val prefs: SharedPreferences
+        get() = appContext.getSharedPreferences(PREFERENCE_NAME, MODE)
+
+    private val defaultProfiles: List<Profile> =
+            listOf(Profile(getString(R.string.filter_name_custom     ), 10, 30, 40, false),
+                   Profile(getString(R.string.filter_name_default    ), 10, 30, 40, false),
+                   Profile(getString(R.string.filter_name_bed_reading), 20, 60, 78, false),
+                   Profile(getString(R.string.filter_name_dim_only   ),  0,  0, 60, false))
+
+    private val mProfiles: ArrayList<Profile> = ArrayList(prefs.all.run {
+        if (isEmpty()) {
+            Log.i("Creating default ProfilesModel")
+            defaultProfiles
+        } else {
+            Log.i("Restoring ProfilesModel")
+            mapKeys{ (k, _) -> k.toInt() }.toSortedMap().map{ (_, v) -> Profile.parse(v as String) }
+        }
+    })
+
+    private fun updateSharedPreferences() {
+        Log.i("Updating SharedPreferences")
+        val editor = prefs.edit()
+        editor.run {
+            clear()
+            mProfiles.forEachIndexed { index, profile ->
+                Log.i("Storing profile $index, ${profile.name}")
+                putString(index.toString(), profile.toString())
+            }
+        }
+        editor.apply()
+        Log.d("Done updating SharedPreferences")
+    }
+
+    fun getProfileName(index: Int): String  = mProfiles[index].name
+    fun getProfile    (index: Int): Profile = mProfiles[index]
+
+    fun setCustom() {
+        mProfiles[0] = Profile(color           = Config.color,
+                               intensity       = Config.intensity,
+                               dimLevel        = Config.dimLevel,
+                               lowerBrightness = Config.lowerBrightness)
+        updateSharedPreferences()
+    }
+
+    private val custom: Profile
+        get() = mProfiles[0]
+
+    fun addProfile(newName: String, fail: Int = 0): Pair<Int, Int> = mProfiles.run {
+        Log.i("addProfile $newName; Current Size: ${mProfiles.size}")
+        val profile = custom.copy(name = newName)
+
+        val success = add(profile)
+        if (success) { updateSharedPreferences() }
+
+        Pair(size, if (success) indexOf(profile) else fail)
+    }
+
+    fun removeProfile(index: Int): Int = mProfiles.run {
+        val profile = removeAt(index)
+        Log.i("removed profile $index: ${profile.name}")
+        setCustom()
+        updateSharedPreferences()
+        size
+    }
+
+    // de-dupe, then append defaults
+    fun reset(): Int = mProfiles.run {
+        remove(custom)
+        removeAll(defaultProfiles)
+        addAll(0, defaultProfiles)
+        updateSharedPreferences()
+        size
+    }
+}

--- a/app/src/main/java/com/jmstudios/redmoon/model/profiles/Profiles.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/model/profiles/Profiles.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017 Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.model.profiles
 

--- a/app/src/main/java/com/jmstudios/redmoon/preference/ProfileSelectorPreference.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/preference/ProfileSelectorPreference.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.preference
 

--- a/app/src/main/java/com/jmstudios/redmoon/preference/SeekBarPreferences.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/preference/SeekBarPreferences.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.preference
 

--- a/app/src/main/java/com/jmstudios/redmoon/preference/TimePickerPreference.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/preference/TimePickerPreference.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.preference
 

--- a/app/src/main/java/com/jmstudios/redmoon/presenter/ScreenFilterPresenter.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/presenter/ScreenFilterPresenter.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/java/com/jmstudios/redmoon/receiver/BootReceiver.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/receiver/BootReceiver.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/java/com/jmstudios/redmoon/receiver/NextProfileCommandReceiver.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/receiver/NextProfileCommandReceiver.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.receiver
 

--- a/app/src/main/java/com/jmstudios/redmoon/receiver/OrientationChangeReceiver.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/receiver/OrientationChangeReceiver.kt
@@ -1,18 +1,6 @@
 /*
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/java/com/jmstudios/redmoon/receiver/ScreenStateReceiver.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/receiver/ScreenStateReceiver.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.receiver
 

--- a/app/src/main/java/com/jmstudios/redmoon/receiver/SwitchAppWidgetProvider.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/receiver/SwitchAppWidgetProvider.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/java/com/jmstudios/redmoon/receiver/TileReceiver.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/receiver/TileReceiver.kt
@@ -1,18 +1,6 @@
 /* Copyright (c) 2017-12-01  cj
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 
 package com.jmstudios.redmoon.receiver

--- a/app/src/main/java/com/jmstudios/redmoon/receiver/TimeToggleChangeReceiver.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/receiver/TimeToggleChangeReceiver.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.receiver
 

--- a/app/src/main/java/com/jmstudios/redmoon/service/LocationUpdateService.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/service/LocationUpdateService.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/java/com/jmstudios/redmoon/service/ScreenFilterService.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/service/ScreenFilterService.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/java/com/jmstudios/redmoon/thread/CurrentAppMonitoringThread.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/thread/CurrentAppMonitoringThread.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.thread
 

--- a/app/src/main/java/com/jmstudios/redmoon/util/Util.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/util/Util.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/java/com/jmstudios/redmoon/view/ScreenFilterView.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/view/ScreenFilterView.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.view
 

--- a/app/src/main/res/color/button.xml
+++ b/app/src/main/res/color/button.xml
@@ -1,19 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
  -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_enabled="false" android:color="@color/text_disabled" />

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -2,19 +2,7 @@
 <!--
 * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
 * Copyright (c) 2017 Stephen Michel <s@smichel.me>
-*
-*  This file is free software: you may copy, redistribute and/or modify it
-*  under the terms of the GNU General Public License as published by the Free
-*  Software Foundation, either version 3 of the License, or (at your option)
-*  any later version.
-*
-*  This file is distributed in the hope that it will be useful, but WITHOUT ANY
-*  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-*  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
-*  details.
-*
-*  You should have received a copy of the GNU General Public License along with
-*  this program.  If not, see <http://www.gnu.org/licenses/>.
+* SPDX-License-Identifier: GPL3.0+
 -->
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout/blank_preference.xml
+++ b/app/src/main/res/layout/blank_preference.xml
@@ -1,19 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" 
     android:layout_width="match_parent"

--- a/app/src/main/res/layout/preference_profile_selector.xml
+++ b/app/src/main/res/layout/preference_profile_selector.xml
@@ -1,19 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
 -->
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout/preference_seekbar.xml
+++ b/app/src/main/res/layout/preference_seekbar.xml
@@ -2,19 +2,7 @@
 <!--
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017 Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
 -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"

--- a/app/src/main/res/layout/preference_summary.xml
+++ b/app/src/main/res/layout/preference_summary.xml
@@ -2,19 +2,7 @@
 <!--
  * Copyright (c) 2017 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017 Stephen Michel <stephen.michel@tufts.edu>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
 -->
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout/switch_bar.xml
+++ b/app/src/main/res/layout/switch_bar.xml
@@ -2,19 +2,7 @@
 <!--
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017 Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" 
     android:layout_width="match_parent"

--- a/app/src/main/res/layout/switch_layout.xml
+++ b/app/src/main/res/layout/switch_layout.xml
@@ -1,19 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
 -->
 <android.support.v7.widget.SwitchCompat
     xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/menu/menu_activity_main.xml
+++ b/app/src/main/res/menu/menu_activity_main.xml
@@ -2,19 +2,7 @@
 <!--
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017 Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
 -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto" >

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -3,19 +3,7 @@
  * Copyright (c) 2016  twckr <https://github.com/twckr>
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
 -->
 <resources>
     <string name="notification_status_paused">Angehalten</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -2,19 +2,7 @@
 <!--
  * Copyright (c) 2016 Danial Behzadi <dani.behzi@ubuntu.com>
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
 -->
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <!-- App Name and Activity Labels -->

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1,19 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,19 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,19 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -2,19 +2,7 @@
 <!--
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,19 +2,7 @@
 <!--
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,19 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,19 +2,7 @@
 <!--
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2016  Stephen Michel <stephen.michel@tufts.edu>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/res/xml/about.xml
+++ b/app/src/main/res/xml/about.xml
@@ -2,19 +2,7 @@
 <!--
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
 -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <Preference

--- a/app/src/main/res/xml/filter_preferences.xml
+++ b/app/src/main/res/xml/filter_preferences.xml
@@ -2,19 +2,7 @@
 <!--
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
  *
  * This file incorporates work covered by the following copyright and
  * permission notice:

--- a/app/src/main/res/xml/secure_suspend_preferences.xml
+++ b/app/src/main/res/xml/secure_suspend_preferences.xml
@@ -2,19 +2,7 @@
 <!--
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
 -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <SwitchPreference

--- a/app/src/main/res/xml/time_toggle_preferences.xml
+++ b/app/src/main/res/xml/time_toggle_preferences.xml
@@ -2,19 +2,7 @@
 <!--
  * Copyright (c) 2016  Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017  Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL3.0+
 -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <SwitchPreference

--- a/app/src/playstore/java/com/jmstudios/redmoon/helper/RateDialog.kt
+++ b/app/src/playstore/java/com/jmstudios/redmoon/helper/RateDialog.kt
@@ -1,19 +1,7 @@
 /*
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * Copyright (c) 2017 Stephen Michel <s@smichel.me>
- *
- *  This file is free software: you may copy, redistribute and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation, either version 3 of the License, or (at your option)
- *  any later version.
- *
- *  This file is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- *  details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0+
  */
 package com.jmstudios.redmoon.helper
 


### PR DESCRIPTION
- Added LICENSE.spdx
  - I did not add all the "required" spdx fields, or even all the ones that would be useful.
  - Feel free to look through the [spec](https://spdx.org/spdx-specification-21-web-version) and add anything you think is relevant.
- Converted the legalize notice to the spdx notice

I did not convert MIT license to use spdx identifiers. I don't think we should do that.

Merge when ready.