### PR TITLE
Add root listener source

### DIFF
--- a/root-listener/listener.cpp
+++ b/root-listener/listener.cpp
@@ -15,7 +15,7 @@ int main(int argc, char** argv) {
 	{
 		if (line == "exit")
 		{
-			std::cout << "Recived exit!\n";
+			std::cout << "Received exit!\n";
 			break;
 		}
 		

--- a/root-listener/listener.cpp
+++ b/root-listener/listener.cpp
@@ -1,0 +1,29 @@
+#include <fstream>
+#include <string>
+#include <iostream>
+
+
+int main(int argc, char** argv) {
+	if (argc < 2)
+	{
+		std::cout << "Usage: " << argv[0] << " <path/to/fifo>\n";
+		return 1;
+	}
+	
+	std::fstream f_pipe(argv[1]);
+	for (std::string line; std::getline(f_pipe, line);)
+	{
+		if (line == "exit")
+		{
+			std::cout << "Recived exit!\n";
+			break;
+		}
+		
+		std::string cmd("service call SurfaceFlinger ");
+		cmd.append(line);
+		popen(cmd.c_str(), "r");
+	}
+	
+	std::cout << "Goodbye!\n";
+	return 0;
+}


### PR DESCRIPTION
`listener.cpp`, when compiled for the right architecture, will listen on an existing fifo at `argv[1]`.
Whenever something is recived on the fifo, it will run `service call SurfaceFlinger <line>`.
To kill the listener, write `exit` to the fifo.